### PR TITLE
Fix typo in ansible repo link

### DIFF
--- a/static/base.html
+++ b/static/base.html
@@ -18,7 +18,7 @@
       </button>
       <ul class="navbar-nav px-3 ms-auto d-none d-lg-flex">
         <li class="nav-item text-nowrap">
-          <a class="nav-link" href="https://github.com/ansible/ansble">GitHub: ansible/ansible</a>
+          <a class="nav-link" href="https://github.com/ansible/ansible">GitHub: ansible/ansible</a>
         </li>
         <li class="nav-item text-nowrap">
           <a class="nav-link" href="https://pypi.org/project/ansible">PyPI: ansible</a>


### PR DESCRIPTION
I noticed broken link for the ansible repo, here is the fix.  